### PR TITLE
Use GDBus instead of pydbus

### DIFF
--- a/com.github.amikha1lov.RecApp.yaml
+++ b/com.github.amikha1lov.RecApp.yaml
@@ -71,15 +71,6 @@ modules:
             url: https://github.com/naelstrof/slop/archive/v7.5.tar.gz
             sha256: 94d8b6270217cd7f56ce7d4a9a75069025262830a2f91c3239b7fc07da5ea8da
 
-      - name: pydbus
-        buildsystem: simple
-        build-commands:
-          - python3 ./setup.py install --prefix=/app --root=/
-        sources:
-          - type: archive
-            url: https://files.pythonhosted.org/packages/58/56/3e84f2c1f2e39b9ea132460183f123af41e3b9c8befe222a35636baa6a5a/pydbus-0.6.0.tar.gz
-            sha256: 4207162eff54223822c185da06c1ba8a34137a9602f3da5a528eedf3f78d0f2c
-
       - name: pulsectl
         buildsystem: simple
         build-commands:

--- a/rpm/recapp.spec
+++ b/rpm/recapp.spec
@@ -23,7 +23,6 @@ Requires:       gstreamer1-plugins-good
 Requires:       gtk3
 Requires:       hicolor-icon-theme
 Requires:       python3-pulsectl
-Requires:       python3-pydbus
 Requires:       slop
 
 # For future

--- a/src/window.py
+++ b/src/window.py
@@ -190,7 +190,7 @@ class RecappWindow(Handy.ApplicationWindow):
             self._capture_mode_box.set_visible(False)
             self._sound_rowbox.set_visible(False)
             self._sound_on_switch.set_active(False)
-            self.bus = SessionBus()
+            self.bus = Gio.bus_get_sync(Gio.BusType.SESSION, None)
             if os.environ['XDG_CURRENT_DESKTOP'] != 'GNOME':
                 self._record_button.set_sensitive(False)
                 notification = Gio.Notification.new(constants["APPNAME"])
@@ -198,8 +198,14 @@ class RecappWindow(Handy.ApplicationWindow):
 
                 self.application.send_notification(None, notification)
             else:
-                self.GNOMEScreencast = self.bus.get('org.gnome.Shell.Screencast',
-                                                    '/org/gnome/Shell/Screencast')
+                self.GNOMEScreencast = Gio.DBusProxy.new_sync(
+                    self.bus,
+                    Gio.DBusProxyFlags.NONE,
+                    None,
+                    "org.gnome.Shell.Screencast",
+                    "/org/gnome/Shell/Screencast",
+                    "org.gnome.Shell.Screencast",
+                    None)
         else:
             self.video_str = "gst-launch-1.0 --eos-on-shutdown ximagesrc use-damage=1 show-pointer={0} ! video/x-raw,framerate={1}/1 ! queue ! videoscale ! videoconvert ! {2} ! queue ! {3} name=mux ! queue ! filesink location='{4}'{5}"
 


### PR DESCRIPTION
Removes the external pydbus dependency in favor of GDBus from GIO.