### PR TITLE
Slight improvements to startup times

### DIFF
--- a/src/rec.py
+++ b/src/rec.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import locale
-import multiprocessing
 import os
 import signal
 import sys
@@ -26,7 +25,6 @@ from locale import gettext as _
 from subprocess import PIPE, Popen
 
 import gi
-import pulsectl
 from pydbus import SessionBus
 
 from .recapp_constants import recapp_constants as constants
@@ -129,6 +127,8 @@ def on__select_area(self):
 def on__sound_switch(self, *args):
     if self._sound_on_switch.get_active():
         self.recordSoundOn = True
+
+        import pulsectl
         with pulsectl.Pulse() as pulse:
             self.soundOnSource = pulse.sink_list()[0].name
             self.settings.set_boolean('record-audio-switch', True)

--- a/src/window.py
+++ b/src/window.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import locale
-import multiprocessing
 import os
 import signal
 import sys
@@ -26,7 +25,6 @@ from locale import gettext as _
 from subprocess import PIPE, Popen
 
 import gi
-import pulsectl
 from pydbus import SessionBus
 
 from .rec import *
@@ -135,7 +133,7 @@ class RecappWindow(Handy.ApplicationWindow):
                       self.on_toggle_microphone)
         accel.connect(Gdk.keyval_from_name('c'), Gdk.ModifierType.CONTROL_MASK, 0,
                       self.on_cancel_record)
-        self.cpus = multiprocessing.cpu_count() - 1
+        self.cpus = os.cpu_count() - 1
         self.add_accel_group(accel)
         self.connect("delete-event", self.on_delete_event)
         Notify.init(constants["APPID"])


### PR DESCRIPTION
Lazily import the pulsectl module, and use the os.cpu_count() method introduced in Python 3.4. Combined with https://github.com/amikha1lov/RecApp/pull/76, the startup times are reduced by ~70 ms.

Relevant issue: https://github.com/amikha1lov/RecApp/issues/73