### PR TITLE
Replace GtkFileChooserButton with custom implementation for GTK4

### DIFF
--- a/data/resources/window.ui
+++ b/data/resources/window.ui
@@ -760,14 +760,11 @@
                             <property name="title" translatable="yes">Saving folder</property>
                             <property name="use-underline">True</property>
                             <child>
-                              <object class="GtkFileChooserButton" id="_video_folder_button">
+                              <object class="GtkButton" id="_video_folder_button">
                                 <property name="visible">True</property>
                                 <property name="can-focus">False</property>
+                                <property name="hexpand">True</property>
                                 <property name="valign">center</property>
-                                <property name="action">select-folder</property>
-                                <property name="do-overwrite-confirmation">True</property>
-                                <property name="title" translatable="yes"/>
-                                <signal name="file-set" handler="on__video_folder_button_file_set" swapped="no"/>
                               </object>
                             </child>
                           </object>

--- a/src/rec.py
+++ b/src/rec.py
@@ -45,8 +45,8 @@ def formats_combobox_changed(self, box):
 
 
 def video_folder_button(self, button):
-    self.settings.set_string('path-to-save-video-folder', self._video_folder_button.get_filename())
-    self._video_folder_button.set_current_folder_uri(
+    self.settings.set_string('path-to-save-video-folder', self._video_folder_button.get_path())
+    self._video_folder_button.set_path(
         self.settings.get_string('path-to-save-video-folder'))
 
 

--- a/src/window.py
+++ b/src/window.py
@@ -162,6 +162,14 @@ class RecappWindow(Handy.ApplicationWindow):
         action.connect("activate", self.openVideoFile)
         self.application.add_action(action)
 
+        # Extend the functionality of our GtkButton
+        self._video_folder_button = FileChooserButton(
+            self._video_folder_button,
+            parent=self,
+            chooser_type="folder",
+            selected_function=self.on__video_folder_button_file_set
+        )
+
         self.currentFolder = self.settings.get_string('path-to-save-video-folder')
 
         if self.currentFolder == "Default":
@@ -179,10 +187,10 @@ class RecappWindow(Handy.ApplicationWindow):
             else:
                 self.settings.set_string('path-to-save-video-folder', GLib.get_user_special_dir(
                     GLib.UserDirectory.DIRECTORY_VIDEOS))
-            self._video_folder_button.set_current_folder_uri(
+            self._video_folder_button.set_path(
                 self.settings.get_string('path-to-save-video-folder'))
         else:
-            self._video_folder_button.set_current_folder_uri(self.currentFolder)
+            self._video_folder_button.set_path(self.currentFolder)
 
         self.displayServer = os.environ['XDG_SESSION_TYPE'].lower()
 
@@ -258,7 +266,6 @@ class RecappWindow(Handy.ApplicationWindow):
             self._time_recording_label.set_label(str(self.elapsed_time).replace(":","∶"))
         return True
 
-    @Gtk.Template.Callback()
     def on__video_folder_button_file_set(self, button):
         video_folder_button(self, button)
 
@@ -373,3 +380,146 @@ class AboutDialog(Gtk.AboutDialog):
 
     def __init__(self, parent):
         Gtk.AboutDialog.__init__(self, transient_for=parent)
+
+class FileChooserButton:
+    # This class extends the functionality of a GtkButton to open a file
+    # chooser and display the name of a selected folder or file
+
+    def __init__(self, button, parent=None, chooser_type="file", selected_function=None):
+
+        self.parent = parent
+        self.button = button
+        self.chooser_type = chooser_type
+        self.selected_function = selected_function
+        self.path = ""
+
+        box = Gtk.Box()
+        box.set_spacing(6)
+        self.icon = Gtk.Image.new()
+
+        if chooser_type == "folder":
+            self.icon.set_from_icon_name("folder-symbolic", Gtk.IconSize.BUTTON)
+        else:
+            self.icon.set_from_icon_name("text-x-generic-symbolic", Gtk.IconSize.BUTTON)
+
+        self.label = Gtk.Label.new(_("(None)"))
+
+        box.add(self.icon)
+        box.add(self.label)
+
+        self.button.add(box)
+        self.button.show_all()
+
+        self.button.connect("clicked", self.open_file_chooser)
+
+    def choose_dir(self, parent=None, initialdir="~", title=_("Select a Folder"), multichoice=True):
+        try:
+            dialog = Gtk.FileChooserNative.new(
+                title,
+                parent,
+                Gtk.FileChooserAction.SELECT_FOLDER,
+                _("_Open"),
+                _("_Cancel")
+            )
+        except AttributeError:
+            dialog = Gtk.FileChooserDialog(
+                title,
+                parent,
+                Gtk.FileChooserAction.SELECT_FOLDER
+            )
+            dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL, _("_Open"), Gtk.ResponseType.ACCEPT)
+
+        if multichoice:
+            dialog.set_select_multiple(True)
+
+        folder = os.path.expanduser(initialdir)
+
+        if os.path.exists(folder):
+            dialog.set_current_folder(folder)
+        else:
+            dialog.set_current_folder(os.path.expanduser("~"))
+
+        response = dialog.run()
+
+        if response == Gtk.ResponseType.ACCEPT:
+            res = dialog.get_filenames()
+        else:
+            res = None
+
+        dialog.destroy()
+
+        return res
+
+    def choose_file(self, parent=None, initialdir="~", title=_("Select a File"), multiple=False):
+        try:
+            dialog = Gtk.FileChooserNative.new(
+                title,
+                parent,
+                Gtk.FileChooserAction.OPEN,
+                _("_Open"),
+                _("_Cancel")
+            )
+        except AttributeError:
+            dialog = Gtk.FileChooserDialog(
+                title,
+                parent,
+                Gtk.FileChooserAction.OPEN
+            )
+            dialog.add_buttons(_("_Cancel"), Gtk.ResponseType.CANCEL, _("_Open"), Gtk.ResponseType.ACCEPT)
+
+        dialog.set_select_multiple(multiple)
+        folder = os.path.expanduser(initialdir)
+
+        if os.path.exists(folder):
+            dialog.set_current_folder(folder)
+        else:
+            dialog.set_current_folder(os.path.expanduser("~"))
+
+        response = dialog.run()
+
+        if response == Gtk.ResponseType.ACCEPT:
+            res = dialog.get_filenames()
+        else:
+            res = None
+
+        dialog.destroy()
+
+        return res
+
+    def open_file_chooser(self, widget):
+
+        if self.chooser_type == "folder":
+            selected = self.choose_dir(self.parent, self.path, multichoice=False)
+
+        else:
+            if self.path:
+                folder_path = os.path.dirname(self.path)
+            else:
+                folder_path = ""
+
+            selected = self.choose_file(self.parent, folder_path)
+
+        if selected:
+            self.set_path(selected[0])
+
+            try:
+                self.selected_function(self)
+
+            except TypeError as e:
+                # No function defined
+                return
+
+    def get_path(self):
+        return self.path
+
+    def set_path(self, path):
+
+        if not path:
+            return
+
+        self.path = path
+        self.label.set_label(os.path.basename(path))
+
+    def clear(self):
+        self.path = ""
+        self.label.set_label(_("(None)"))


### PR DESCRIPTION
GtkFileChooserButton was removed in GTK4. https://developer.gnome.org/gtk4/unstable/ch41s02.html#id-1.7.4.4.85

In another project I currently maintain, I noticed that our numerous GtkFileChooserButton widgets were responsible for large slowdowns on initial load. This PR may help with https://github.com/amikha1lov/RecApp/issues/73, although the difference should be quite small, as there's only one button in this app.

Closes https://github.com/amikha1lov/RecApp/issues/71